### PR TITLE
Feature/add support for querying active correlations

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Uses sequelize to access and manipulate flow node instance data.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@essential-projects/iam_contracts": "^3.0.0",
     "@essential-projects/sequelize_connection_manager": "^1.0.0",
-    "@process-engine/process_engine_contracts": "^14.0.0",
+    "@process-engine/process_engine_contracts": "feature~add_support_for_querying_active_correlations",
     "loggerhythm": "^3.0.3",
     "pg": "^7.4.3",
     "pg-hstore": "^2.3.2",

--- a/src/flow_node_instance_repository.ts
+++ b/src/flow_node_instance_repository.ts
@@ -280,10 +280,10 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
     processToken.processInstanceId = dataModel.processInstanceId;
     processToken.processModelId = dataModel.processModelId;
     processToken.correlationId = dataModel.correlationId;
-    processToken.identity = JSON.parse(dataModel.identity);
+    processToken.identity = dataModel.identity ? JSON.parse(dataModel.identity) : undefined;
     processToken.createdAt = dataModel.createdAt;
     processToken.caller = dataModel.caller;
-    processToken.payload = JSON.parse(dataModel.payload);
+    processToken.payload = dataModel.payload ? JSON.parse(dataModel.payload) : {};
 
     return processToken;
   }

--- a/src/flow_node_instance_repository.ts
+++ b/src/flow_node_instance_repository.ts
@@ -47,6 +47,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
     const createParams: any = {
       flowNodeId: flowNodeId,
       flowNodeInstanceId: flowNodeInstanceId,
+      state: Runtime.Types.FlowNodeInstanceState.running,
       isSuspended: false,
       processToken: persistableProcessToken,
     };
@@ -83,6 +84,8 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
     if (!matchingFlowNodeInstance) {
       throw new Error(`flow node with instance id '${flowNodeInstanceId}' not found!`);
     }
+
+    matchingFlowNodeInstance.state = Runtime.Types.FlowNodeInstanceState.finished;
 
     const currentToken: ProcessToken = matchingFlowNodeInstance.processToken;
     const updatedToken: ProcessToken = Object.assign(currentToken, newProcessToken);
@@ -241,6 +244,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
     const runtimeFlowNodeInstance: Runtime.Types.FlowNodeInstance = new Runtime.Types.FlowNodeInstance();
     runtimeFlowNodeInstance.id = dataModel.flowNodeInstanceId;
     runtimeFlowNodeInstance.flowNodeId = dataModel.flowNodeId;
+    runtimeFlowNodeInstance.state = dataModel.state;
     runtimeFlowNodeInstance.isSuspended = dataModel.isSuspended;
 
     const processToken: Runtime.Types.ProcessToken = this._convertProcessTokenToRuntimeObject(dataModel.processToken);

--- a/src/flow_node_instance_repository.ts
+++ b/src/flow_node_instance_repository.ts
@@ -99,6 +99,26 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
     return runtimeFlowNodeInstance;
   }
 
+  public async queryByState(state: Runtime.Types.FlowNodeInstanceState): Promise<Array<Runtime.Types.FlowNodeInstance>> {
+
+    const results: Array<FlowNodeInstanceModel> = await this.flowNodeInstanceModel.findAll({
+      where: {
+        state: state,
+      },
+      include: [{
+        model: this.processTokenModel,
+        as: 'processToken',
+        required: true,
+      }],
+    });
+
+    // TODO - BUG: For some reason the "this" context gets lost here, unless a bind is made.
+    // This effect has thus far been observed only in those operations that involve the consumer api.
+    const flowNodeInstances: Array<Runtime.Types.FlowNodeInstance> = results.map(this._convertFlowNodeInstanceToRuntimeObject.bind(this));
+
+    return flowNodeInstances;
+  }
+
   public async queryByCorrelation(correlationId: string): Promise<Array<Runtime.Types.FlowNodeInstance>> {
 
     const results: Array<FlowNodeInstanceModel> = await this.flowNodeInstanceModel.findAll({

--- a/src/schemas/flow_node_instance.ts
+++ b/src/schemas/flow_node_instance.ts
@@ -1,11 +1,14 @@
 import * as Sequelize from 'sequelize';
 import {ProcessToken} from './process_token';
 
+import {Runtime} from '@process-engine/process_engine_contracts';
+
 export interface IFlowNodeInstanceAttributes {
   id: string;
   flowNodeInstanceId: string;
   flowNodeId: string;
   isSuspended: boolean;
+  state: Runtime.Types.FlowNodeInstanceState;
   // Contains the association to the ProcessToken model.
   // Must be optional, otherwise this property will be expected in the attribute payload of `sequelize.define`.
   processToken?: ProcessToken;
@@ -28,6 +31,11 @@ export function defineFlowNodeInstance(sequelize: Sequelize.Sequelize): Sequeliz
     flowNodeId: {
       type: Sequelize.STRING,
       allowNull: false,
+    },
+    state: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
     },
     isSuspended: {
       type: Sequelize.BOOLEAN,


### PR DESCRIPTION
## What did you change?

- Add `state` property to the flow node instance schema (See https://github.com/process-engine/process_engine_contracts/pull/49 for details)
  - Set `running` state during `persistOnEnter`
  - Set `finished` state during `persistOnExit`
- Improve data parsing for `payload` and `identity`, which may be null/undefined on occasion
- Add a `queryByState` function which allows to retrieve all flow node instances with a specific state

## How can others test the changes?

Use the Flow Node Instance Repository to query all flow nodes with a running or finished state.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
