### PR TITLE
Feature/manually set default date value

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Uses sequelize to access and manipulate flow node instance data.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -15,7 +15,7 @@
   "dependencies": {
     "@essential-projects/iam_contracts": "^3.0.0",
     "@essential-projects/sequelize_connection_manager": "^1.0.1",
-    "@process-engine/process_engine_contracts": "^16.0.0",
+    "@process-engine/process_engine_contracts": "^17.1.0",
     "loggerhythm": "^3.0.3",
     "pg": "^7.4.3",
     "pg-hstore": "^2.3.2",
@@ -28,6 +28,7 @@
     "gulp": "^3.9.1",
     "gulptraum": "^2.2.4",
     "gulptraum-typescript": "^1.3.9",
+    "moment": "^2.22.2",
     "tsconfig": "^7.0.0",
     "tslint": "^5.7.0",
     "typescript": "^2.5.2"

--- a/src/schemas/process_token.ts
+++ b/src/schemas/process_token.ts
@@ -1,3 +1,4 @@
+import * as moment from 'moment';
 import * as Sequelize from 'sequelize';
 
 export interface IProcessTokenAttributes {
@@ -41,7 +42,7 @@ export function defineProcessToken(sequelize: Sequelize.Sequelize): Sequelize.Mo
     createdAt: {
       type: Sequelize.DATE,
       allowNull: true,
-      defaultValue: sequelize.fn('NOW'),
+      defaultValue: moment.utc().toDate(),
     },
     caller: {
       type: Sequelize.STRING,


### PR DESCRIPTION
## What did you change?

Use `moment` to manually set a date for the process tokens `createdAt` property.

This is necessary, because apparently, sqlite does not support the `NOW` function provided by sequelize.

## How can others test the changes?

Store a process token with sqlite.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
