### PR TITLE
Feature/reactivate terminate end event

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Uses sequelize to access and manipulate flow node instance data.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -16,9 +16,9 @@
     "@essential-projects/iam_contracts": "^3.0.0",
     "@essential-projects/sequelize_connection_manager": "^1.0.1",
     "@process-engine/process_engine_contracts": "^18.0.0",
+    "@types/clone": "^0.1.30",
+    "clone": "^2.1.2",
     "loggerhythm": "^3.0.3",
-    "pg": "^7.4.3",
-    "pg-hstore": "^2.3.2",
     "sequelize": "^4.38.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@essential-projects/iam_contracts": "^3.0.0",
     "@essential-projects/sequelize_connection_manager": "^1.0.1",
-    "@process-engine/process_engine_contracts": "^18.0.0",
+    "@process-engine/process_engine_contracts": "feature~reactivate_terminate_end_event",
     "@types/clone": "^0.1.30",
     "clone": "^2.1.2",
     "loggerhythm": "^3.0.3",

--- a/src/flow_node_instance_repository.ts
+++ b/src/flow_node_instance_repository.ts
@@ -81,14 +81,14 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
     return this._persistOnStateChange(newProcessToken, flowNodeId, flowNodeInstanceId, Runtime.Types.FlowNodeInstanceState.error, error);
   }
 
-  public async persistOnTerminate(newProcessToken: Runtime.Types.ProcessToken,
+  public async persistOnTerminate(token: Runtime.Types.ProcessToken,
                              flowNodeId: string,
                              flowNodeInstanceId: string): Promise<Runtime.Types.FlowNodeInstance> {
 
-    return this._persistOnStateChange(newProcessToken, flowNodeId, flowNodeInstanceId, Runtime.Types.FlowNodeInstanceState.terminated);
+    return this._persistOnStateChange(token, flowNodeId, flowNodeInstanceId, Runtime.Types.FlowNodeInstanceState.terminated);
   }
 
-  private async _persistOnStateChange(newProcessToken: Runtime.Types.ProcessToken,
+  private async _persistOnStateChange(token: Runtime.Types.ProcessToken,
                                       flowNodeId: string,
                                       flowNodeInstanceId: string,
                                       newState: Runtime.Types.FlowNodeInstanceState,
@@ -117,9 +117,9 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
     }
 
     const currentToken: ProcessToken = matchingFlowNodeInstance.processToken;
-    const updatedToken: ProcessToken = Object.assign(currentToken, newProcessToken);
-    updatedToken.identity = JSON.stringify(newProcessToken.identity);
-    updatedToken.payload = JSON.stringify(newProcessToken.payload);
+    const updatedToken: ProcessToken = Object.assign(currentToken, token);
+    updatedToken.identity = JSON.stringify(token.identity);
+    updatedToken.payload = JSON.stringify(token.payload);
 
     matchingFlowNodeInstance.processToken = updatedToken;
     matchingFlowNodeInstance.save();

--- a/src/flow_node_instance_repository.ts
+++ b/src/flow_node_instance_repository.ts
@@ -1,6 +1,7 @@
 import {getConnection} from '@essential-projects/sequelize_connection_manager';
 import {IFlowNodeInstanceRepository, Runtime} from '@process-engine/process_engine_contracts';
 
+import * as clone from 'clone';
 import * as Sequelize from 'sequelize';
 
 import {loadModels} from './model_loader';
@@ -40,7 +41,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
                               flowNodeId: string,
                               flowNodeInstanceId: string): Promise<Runtime.Types.FlowNodeInstance> {
 
-    const persistableProcessToken: any = Object.assign({}, processToken);
+    const persistableProcessToken: any = clone(processToken);
     persistableProcessToken.identity = JSON.stringify(persistableProcessToken.identity);
     persistableProcessToken.payload = JSON.stringify(persistableProcessToken.payload);
 
@@ -69,34 +70,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
                              flowNodeId: string,
                              flowNodeInstanceId: string): Promise<Runtime.Types.FlowNodeInstance> {
 
-    const matchingFlowNodeInstance: FlowNodeInstanceModel = await this.flowNodeInstanceModel.findOne({
-      where: {
-        flowNodeId: flowNodeId,
-        flowNodeInstanceId: flowNodeInstanceId,
-      },
-      include: [{
-        model: this.processTokenModel,
-        as: 'processToken',
-        required: true,
-      }],
-    });
-
-    if (!matchingFlowNodeInstance) {
-      throw new Error(`flow node with instance id '${flowNodeInstanceId}' not found!`);
-    }
-
-    matchingFlowNodeInstance.state = Runtime.Types.FlowNodeInstanceState.finished;
-
-    const currentToken: ProcessToken = matchingFlowNodeInstance.processToken;
-    const updatedToken: ProcessToken = Object.assign(currentToken, newProcessToken);
-    updatedToken.identity = JSON.stringify(newProcessToken.identity);
-    updatedToken.payload = JSON.stringify(newProcessToken.payload);
-
-    matchingFlowNodeInstance.processToken = updatedToken;
-    matchingFlowNodeInstance.save();
-    const runtimeFlowNodeInstance: Runtime.Types.FlowNodeInstance = this._convertFlowNodeInstanceToRuntimeObject(matchingFlowNodeInstance);
-
-    return runtimeFlowNodeInstance;
+    return this._persistOnStateChange(newProcessToken, flowNodeId, flowNodeInstanceId, Runtime.Types.FlowNodeInstanceState.finished);
   }
 
   public async persistOnError(newProcessToken: Runtime.Types.ProcessToken,
@@ -104,6 +78,22 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
                              flowNodeInstanceId: string,
                              error: Error): Promise<Runtime.Types.FlowNodeInstance> {
 
+    return this._persistOnStateChange(newProcessToken, flowNodeId, flowNodeInstanceId, Runtime.Types.FlowNodeInstanceState.error, error);
+  }
+
+  public async persistOnTerminate(newProcessToken: Runtime.Types.ProcessToken,
+                             flowNodeId: string,
+                             flowNodeInstanceId: string): Promise<Runtime.Types.FlowNodeInstance> {
+
+    return this._persistOnStateChange(newProcessToken, flowNodeId, flowNodeInstanceId, Runtime.Types.FlowNodeInstanceState.terminated);
+  }
+
+  private async _persistOnStateChange(newProcessToken: Runtime.Types.ProcessToken,
+                                      flowNodeId: string,
+                                      flowNodeInstanceId: string,
+                                      newState: Runtime.Types.FlowNodeInstanceState,
+                                      error?: Error): Promise<Runtime.Types.FlowNodeInstance> {
+
     const matchingFlowNodeInstance: FlowNodeInstanceModel = await this.flowNodeInstanceModel.findOne({
       where: {
         flowNodeId: flowNodeId,
@@ -120,8 +110,11 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
       throw new Error(`flow node with instance id '${flowNodeInstanceId}' not found!`);
     }
 
-    matchingFlowNodeInstance.state = Runtime.Types.FlowNodeInstanceState.error;
-    matchingFlowNodeInstance.error = error.toString();
+    matchingFlowNodeInstance.state = newState;
+
+    if (error) {
+      matchingFlowNodeInstance.error = error.toString();
+    }
 
     const currentToken: ProcessToken = matchingFlowNodeInstance.processToken;
     const updatedToken: ProcessToken = Object.assign(currentToken, newProcessToken);


### PR DESCRIPTION
Depends on: 
https://github.com/process-engine/process_engine_contracts/pull/60

## What did you change?

- Add `persistOnTerminate` function
- Move all commonly used functions for affecting a state change into a private function named `_persistOnStateChange`
- Remove redundant dependencies to postgres libraries
  - These are only to be installed through the implementing application, since sequelize supports many more database technologies than just postgres

## How can others test the changes?

Run the integrationtest for the `TerminateEndEvent`.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
