### PR TITLE
Dynamic user task expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@essential-projects/iam_contracts": "^3.0.0",
     "@essential-projects/sequelize_connection_manager": "^1.0.1",
-    "@process-engine/process_engine_contracts": "^18.0.0",
+    "@process-engine/process_engine_contracts": "feature~dynamic_user_task_expressions",
     "loggerhythm": "^3.0.3",
     "pg": "^7.4.3",
     "pg-hstore": "^2.3.2",

--- a/src/flow_node_instance_repository.ts
+++ b/src/flow_node_instance_repository.ts
@@ -36,6 +36,28 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
     this._processTokenModel = this.sequelize.models.ProcessToken;
   }
 
+  public async getFlowNodeInstanceById(flowNodeInstanceId: string): Promise<Runtime.Types.FlowNodeInstance> {
+
+    const matchingFlowNodeInstance: FlowNodeInstanceModel = await this.flowNodeInstanceModel.findOne({
+      where: {
+        flowNodeInstanceId: flowNodeInstanceId,
+      },
+      include: [{
+        model: this.processTokenModel,
+        as: 'processToken',
+        required: true,
+      }],
+    });
+
+    if (matchingFlowNodeInstance === null) {
+      return null;
+    }
+
+    const flowNodeInstance: Runtime.Types.FlowNodeInstance = this._convertFlowNodeInstanceToRuntimeObject(matchingFlowNodeInstance);
+
+    return flowNodeInstance;
+  }
+
   public async persistOnEnter(processToken: Runtime.Types.ProcessToken,
                               flowNodeId: string,
                               flowNodeInstanceId: string): Promise<Runtime.Types.FlowNodeInstance> {
@@ -43,6 +65,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
     const persistableProcessToken: any = Object.assign({}, processToken);
     persistableProcessToken.identity = JSON.stringify(persistableProcessToken.identity);
     persistableProcessToken.payload = JSON.stringify(persistableProcessToken.payload);
+    persistableProcessToken.flowNodeInstanceId = flowNodeInstanceId;
 
     const createParams: any = {
       flowNodeId: flowNodeId,
@@ -94,15 +117,16 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
 
     matchingFlowNodeInstance.processToken = updatedToken;
     matchingFlowNodeInstance.save();
+    matchingFlowNodeInstance.processToken.save();
     const runtimeFlowNodeInstance: Runtime.Types.FlowNodeInstance = this._convertFlowNodeInstanceToRuntimeObject(matchingFlowNodeInstance);
 
     return runtimeFlowNodeInstance;
   }
 
   public async persistOnError(newProcessToken: Runtime.Types.ProcessToken,
-                             flowNodeId: string,
-                             flowNodeInstanceId: string,
-                             error: Error): Promise<Runtime.Types.FlowNodeInstance> {
+                              flowNodeId: string,
+                              flowNodeInstanceId: string,
+                              error: Error): Promise<Runtime.Types.FlowNodeInstance> {
 
     const matchingFlowNodeInstance: FlowNodeInstanceModel = await this.flowNodeInstanceModel.findOne({
       where: {
@@ -133,6 +157,19 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
     const runtimeFlowNodeInstance: Runtime.Types.FlowNodeInstance = this._convertFlowNodeInstanceToRuntimeObject(matchingFlowNodeInstance);
 
     return runtimeFlowNodeInstance;
+  }
+
+  public async queryProcessTokensByProcessInstance(processInstanceId: string): Promise<Array<Runtime.Types.ProcessToken>> {
+
+    const processInstanceTokens: Array<ProcessToken> = await this.processTokenModel.findAll({
+      where: {
+        processInstanceId: processInstanceId,
+      },
+    });
+
+    const flowNodeInstances: Array<Runtime.Types.ProcessToken> = processInstanceTokens.map(this._convertProcessTokenToRuntimeObject.bind(this));
+
+    return flowNodeInstances;
   }
 
   public async queryByState(state: Runtime.Types.FlowNodeInstanceState): Promise<Array<Runtime.Types.FlowNodeInstance>> {
@@ -317,6 +354,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
     processToken.processInstanceId = dataModel.processInstanceId;
     processToken.processModelId = dataModel.processModelId;
     processToken.correlationId = dataModel.correlationId;
+    processToken.flowNodeInstanceId = dataModel.flowNodeInstanceId;
     processToken.identity = dataModel.identity ? JSON.parse(dataModel.identity) : undefined;
     processToken.createdAt = dataModel.createdAt;
     processToken.caller = dataModel.caller;

--- a/src/flow_node_instance_repository.ts
+++ b/src/flow_node_instance_repository.ts
@@ -105,8 +105,8 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
   }
 
   public async persistOnTerminate(token: Runtime.Types.ProcessToken,
-                             flowNodeId: string,
-                             flowNodeInstanceId: string): Promise<Runtime.Types.FlowNodeInstance> {
+                                  flowNodeId: string,
+                                  flowNodeInstanceId: string): Promise<Runtime.Types.FlowNodeInstance> {
 
     return this._persistOnStateChange(token, flowNodeId, flowNodeInstanceId, Runtime.Types.FlowNodeInstanceState.terminated);
   }
@@ -146,6 +146,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository {
 
     matchingFlowNodeInstance.processToken = updatedToken;
     matchingFlowNodeInstance.save();
+    matchingFlowNodeInstance.processToken.save();
     const runtimeFlowNodeInstance: Runtime.Types.FlowNodeInstance = this._convertFlowNodeInstanceToRuntimeObject(matchingFlowNodeInstance);
 
     return runtimeFlowNodeInstance;

--- a/src/model_loader.ts
+++ b/src/model_loader.ts
@@ -16,7 +16,7 @@ export async function loadModels(sequelizeInstance: Sequelize.Sequelize): Promis
 
   flowNodeInstance.hasOne(processToken, {
     as: 'processToken',
-    foreignKey: 'flowNodeInstanceId',
+    foreignKey: 'flowNodeInstanceForeignKey',
   });
 
   await sequelizeInstance.sync();

--- a/src/schemas/process_token.ts
+++ b/src/schemas/process_token.ts
@@ -6,6 +6,7 @@ export interface IProcessTokenAttributes {
   processInstanceId: string;
   processModelId: string;
   correlationId: string;
+  flowNodeInstanceId: string;
   identity: string;
   createdAt: Date;
   caller?: string; // Only set, if the process token belongs to a subprocess
@@ -27,6 +28,10 @@ export function defineProcessToken(sequelize: Sequelize.Sequelize): Sequelize.Mo
     },
     processModelId: {
       type: Sequelize.STRING,
+      allowNull: false,
+    },
+    flowNodeInstanceId: {
+      type: Sequelize.UUID,
       allowNull: false,
     },
     correlationId: {


### PR DESCRIPTION
## What did you change?

* implemented `getFlowNodeInstanceById`-method
* implemented `queryProcessTokensByProcessInstance`-method
* renamed `flowNodeInstanceId` to `flowNodeInstanceForeignKey` on sequelize relation to avoid confusion
   * the property refers to the `id` (primary key) attribute of `FlowNodeInstance` in the database - it doesn't refer to the also present `flowNodeInstanceId`-property
* added `flowNodeInstanceId` to `ProcessToken` for referencing the `FlowNodeInstance` a `ProcessToken` belongs to
* added another `save()`-call to `persistOnExit()`, because without it only the `FlowNodeInstance` was updated - **not** the `ProcessToken`

## How can others test the changes?

See https://github.com/process-engine/process_engine_meta/pull/126.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
