### PR TITLE
✨ Add sequelize transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@essential-projects/errors_ts": "~1.4.0",
     "@essential-projects/iam_contracts": "~3.2.0",
     "@essential-projects/sequelize_connection_manager": "~2.1.0",
-    "@process-engine/process_engine_contracts": "~36.3.0",
+    "@process-engine/process_engine_contracts": "~36.4.0",
     "@types/clone": "~0.1.30",
     "clone": "~2.1.2",
     "loggerhythm": "~3.0.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "8.2.0",
+  "version": "8.3.0",
   "description": "Uses sequelize to access and manipulate flow node instance data.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/flow_node_instance_repository.ts
+++ b/src/flow_node_instance_repository.ts
@@ -524,7 +524,10 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
 
       return updatedFlowNodeInstance;
     } catch (error) {
-      logger.error(`Failed to change state of FlowNode ${flowNodeId} with instance ID ${flowNodeInstanceId}!`, error);
+      logger.error(
+        `Failed to change state of FlowNode ${flowNodeId} with instance ID ${flowNodeInstanceId} to '${newState}'!`,
+        matchingFlowNodeInstance, error,
+      );
       throw error;
     }
   }

--- a/src/flow_node_instance_repository.ts
+++ b/src/flow_node_instance_repository.ts
@@ -378,24 +378,28 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
       return flowNodeInstance.id;
     }));
 
-    const flowNodeQueryParams: Sequelize.DestroyOptions = {
-      where: {
-        flowNodeInstanceId: {
-          $in: flowNodeInstanceIdsToRemove,
+    await this._sequelize.transaction(async(deleteTransaction: Sequelize.Transaction): Promise<void> => {
+      const flowNodeQueryParams: Sequelize.DestroyOptions = {
+        where: {
+          flowNodeInstanceId: {
+            $in: flowNodeInstanceIdsToRemove,
+          },
         },
-      },
-    };
+        transaction: deleteTransaction,
+      };
 
-    const processTokenQueryParams: Sequelize.DestroyOptions = {
-      where: {
-        flowNodeInstanceId: {
-          $in: flowNodeInstanceIdsToRemove,
+      const processTokenQueryParams: Sequelize.DestroyOptions = {
+        where: {
+          flowNodeInstanceId: {
+            $in: flowNodeInstanceIdsToRemove,
+          },
         },
-      },
-    };
+        transaction: deleteTransaction,
+      };
 
-    await this.processTokenModel.destroy(processTokenQueryParams);
-    await this.flowNodeInstanceModel.destroy(flowNodeQueryParams);
+      await this.processTokenModel.destroy(processTokenQueryParams);
+      await this.flowNodeInstanceModel.destroy(flowNodeQueryParams);
+    });
   }
 
   public async persistOnEnter(flowNode: Model.Base.FlowNode,

--- a/src/flow_node_instance_repository.ts
+++ b/src/flow_node_instance_repository.ts
@@ -431,8 +431,10 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
 
       return this.queryByInstanceId(flowNodeInstanceId);
     } catch (error) {
-      await createTransaction.rollback();
       logger.error(`Failed to persist new instance for FlowNode ${flowNode.id}, using instance id ${flowNodeInstanceId}!`, error);
+
+      await createTransaction.rollback();
+
       throw error;
     }
   }
@@ -528,7 +530,9 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
         `Failed to change state of FlowNode ${flowNodeId} with instance ID ${flowNodeInstanceId} to '${newState}'!`,
         token, error,
       );
+
       await createTransaction.rollback();
+
       throw error;
     }
   }

--- a/src/flow_node_instance_repository.ts
+++ b/src/flow_node_instance_repository.ts
@@ -524,7 +524,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
 
       return updatedFlowNodeInstance;
     } catch (error) {
-      logger.error(`Failed to change state of FlowNodeInstance with ID ${flowNodeInstanceId}!`, error);
+      logger.error(`Failed to change state of FlowNode ${flowNodeId} with instance ID ${flowNodeInstanceId}!`, error);
       throw error;
     }
   }


### PR DESCRIPTION
**Changes:**

Implement Sequelize Transaction for creating, updating and deleting database entries, to prevent database corruption if a request fails.
- For creating and updating FlowNodeInstances, unmanaged transactions are used to reduce latency when multiple FlowNodeInstances need to be created/updated simultaneously.
Using managed transactions for this UseCase would result in all those parallel state transitions to be run sequentially, which can significantly slow down performance.
- For deleting FlowNodeInstances, managed transactions are used, to reduce the code overhead.
It is highly unlikely that multiple delete-requests will ever run completely in parallel anyway.


**Issues:**

Closes #28 
Part of https://github.com/process-engine/process_engine_runtime/issues/188

PR: #31

## How can others test the changes?

To the outside observer, all should work as before.
However, when one query fails during process definition persisting, the entire transaction will be rolled back and no database corruption will occur.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).