### PR TITLE
🐛 Fix error deserialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "@essential-projects/bootstrapper_contracts": "^1.3.0",
-    "@essential-projects/errors_ts": "feature~fix_error_serialization",
+    "@essential-projects/errors_ts": "^1.4.5",
     "@essential-projects/sequelize_connection_manager": "^2.1.0",
     "@process-engine/flow_node_instance.contracts": "^1.0.0",
     "@types/clone": "^0.1.30",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "@essential-projects/bootstrapper_contracts": "^1.3.0",
-    "@essential-projects/errors_ts": "^1.4.0",
+    "@essential-projects/errors_ts": "feature~fix_error_serialization",
     "@essential-projects/sequelize_connection_manager": "^2.1.0",
     "@process-engine/flow_node_instance.contracts": "^1.0.0",
     "@types/clone": "^0.1.30",

--- a/src/flow_node_instance_repository.ts
+++ b/src/flow_node_instance_repository.ts
@@ -1,4 +1,3 @@
-// tslint:disable:max-file-line-count
 import {Logger} from 'loggerhythm';
 import * as Sequelize from 'sequelize';
 

--- a/src/flow_node_instance_repository.ts
+++ b/src/flow_node_instance_repository.ts
@@ -511,12 +511,14 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
     return this._persistOnStateChange(flowNodeId, flowNodeInstanceId, processToken, flowNodeInstanceState, processTokenType);
   }
 
-  private async _persistOnStateChange(flowNodeId: string,
-                                      flowNodeInstanceId: string,
-                                      token: ProcessToken,
-                                      newState: FlowNodeInstanceState,
-                                      processTokenType: ProcessTokenType,
-                                      error?: Error): Promise<FlowNodeInstance> {
+  private async _persistOnStateChange(
+    flowNodeId: string,
+    flowNodeInstanceId: string,
+    token: ProcessToken,
+    newState: FlowNodeInstanceState,
+    processTokenType: ProcessTokenType,
+    error?: Error,
+  ): Promise<FlowNodeInstance> {
 
     const matchingFlowNodeInstance: FlowNodeInstanceModel = await this._flowNodeInstanceModel.findOne({
       where: {
@@ -558,10 +560,12 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
     }
   }
 
-  private async _createProcessTokenForFlowNodeInstance(flowNodeInstanceId: string,
-                                                       token: ProcessToken,
-                                                       type: ProcessTokenType,
-                                                       createTransaction: Sequelize.Transaction): Promise<void> {
+  private async _createProcessTokenForFlowNodeInstance(
+    flowNodeInstanceId: string,
+    token: ProcessToken,
+    type: ProcessTokenType,
+    createTransaction: Sequelize.Transaction,
+  ): Promise<void> {
 
     const createParams: IProcessTokenAttributes = {
       type: type,


### PR DESCRIPTION
**Changes:**

`JSON.stringify` does not include an error's message with the string.
To get around this problem, the repository will now make use of the `@essential-project/error_ts` serialization/deserialization feature to store errors, if possible.
Most errors we pass around come from that package anyway, so we should be fine with this. 

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/309

PR: #36

## How can others test the changes?

- Run a Process that ends with a FlowNode that runs into an error.
- When that error gets persisted, the serialized string of that error gets stored.
- When retrieving the FlowNodeInstance from the database, the error is fully deserialized.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).