### PR TITLE
♻️ Change error column type to text

### DIFF
--- a/src/schemas/flow_node_instance.ts
+++ b/src/schemas/flow_node_instance.ts
@@ -62,8 +62,6 @@ export function defineFlowNodeInstance(sequelize: Sequelize.Sequelize): Sequeliz
       allowNull: true,
     },
     identity: {
-      // Since the identity is also a serialised object, we should use TEXT instead of string here.
-      // See ProcessToken.Payload.
       type: Sequelize.TEXT,
       allowNull: true,
     },
@@ -73,7 +71,7 @@ export function defineFlowNodeInstance(sequelize: Sequelize.Sequelize): Sequeliz
       defaultValue: 0,
     },
     error: {
-      type: Sequelize.STRING,
+      type: Sequelize.TEXT,
       allowNull: true,
     },
     previousFlowNodeInstanceId: {

--- a/src/schemas/process_token.ts
+++ b/src/schemas/process_token.ts
@@ -19,7 +19,6 @@ export function defineProcessToken(sequelize: Sequelize.Sequelize): Sequelize.Mo
       allowNull: true,
     },
     payload: {
-      // NOTE: Use Sequelize.TEXT, since payloads can contain all kinds of things and could therefore exceed 255 chars.
       type: Sequelize.TEXT,
       allowNull: true,
     },


### PR DESCRIPTION
**Changes:**

1. Change the schema type for `FlowNodeInstance.error` to `TEXT`
    - Using `STRING` here is insufficient, because it would limit the column to 255 chars with postgres. This is not enough for error objects.
2. Remove some redundant comments.

PR: #37

## How can others test the changes?

- Run a process and provoke an error on a FlowNode, using Postgres as database
- See that the error gets stored correctly.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).