### PR TITLE
🐛 Store all previousFlowNodeInstanceIds for ParallelJoinGateways

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "10.0.1",
+  "version": "10.1.0",
   "description": "Uses sequelize to access and manipulate flow node instance data.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/flow_node_instance_repository.ts
+++ b/src/flow_node_instance_repository.ts
@@ -470,11 +470,10 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
 
     const createTransaction = await this.sequelizeInstance.transaction();
     try {
-      // Workaround for solving the Problem with multiple previousFlowNodeInstanceIds for ParallelJoinGateways.
+      // Workaround for solving the problem with multiple previousFlowNodeInstanceIds for ParallelJoinGateways.
       if (matchingFlowNodeInstance) {
         matchingFlowNodeInstance.previousFlowNodeInstanceId = previousFlowNodeInstanceId;
         await matchingFlowNodeInstance.save({transaction: createTransaction});
-
       } else {
 
         await FlowNodeInstanceModel.create(createParams, {transaction: createTransaction});

--- a/src/flow_node_instance_repository.ts
+++ b/src/flow_node_instance_repository.ts
@@ -462,9 +462,6 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
     };
 
     const initialState = ProcessTokenType.onEnter;
-
-    // NOTE: This must happen prior to creating the transaction, or we risk running into timeouts with postgres and mysql.
-    // This behavior has been observed when dealing with multiple parallel execution branches.
     const matchingFlowNodeInstance = await FlowNodeInstanceModel.findOne({
       where: {
         flowNodeInstanceId: flowNodeInstanceId,


### PR DESCRIPTION
## Changes

Allow `persistOnEnter` to overwrite existing FlowNodeInstances.
This is required to allow ParallelJoinGateways to store all the IDs of preceeding FlowNodeInstances.

Only the `previousFlowNodeInstanceId` property gets overwritten, to minimize the impact.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/245

PR: #40

## How to test the changes

- Run some ProcessModels that use ParallelJoinGateways
- Inspect the database and see that the corresponding FlowNodeInstance has all its `previousFlowNodeInstanceIds`.
